### PR TITLE
invalid choice: get-transcription-job-results

### DIFF
--- a/doc_source/getting-started-cli.md
+++ b/doc_source/getting-started-cli.md
@@ -85,10 +85,7 @@ To transcribe text, you have to provide the input parameters in a JSON file\.
 1. When the job has the status `COMPLETED`, get the results of the job\. Type the following command:
 
    ```
-   aws transcribe get-transcription-job-results \
-      --endpoint-url endpoint \
-      --region endpoint \
-      --request-id "DocTest-01"
+   aws transcribe get-transcription-job --transcription-job-name "request ID" 
    ```
 
    Amazon Transcribe responds with the following:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

changed call to retrieve results from:

```
aws transcribe get-transcription-job-results ...
```
To:

`aws transcribe get-transcription-job --transcription-job-name "request ID here"`

due to get-transcription-job-results not being taken as a valid option in aws cli

_Original command._ 
![screen shot 2018-03-05 at 11 42 07 am](https://user-images.githubusercontent.com/15708178/36987443-4c5d11b2-206a-11e8-956c-af6d9cc0d63a.png)

_after aws transcribe get-transcription-job --transcription-job-name "request ID here"_
![screen shot 2018-03-05 at 11 43 51 am](https://user-images.githubusercontent.com/15708178/36987814-41540324-206b-11e8-9633-f10248097ee2.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.