### PR TITLE
Fix S3 URL format to use . not - before region name

### DIFF
--- a/doc_source/API_CreateVocabulary.md
+++ b/doc_source/API_CreateVocabulary.md
@@ -33,9 +33,9 @@ Required: No
 
  ** [VocabularyFileUri](#API_CreateVocabulary_RequestSyntax) **   <a name="transcribe-CreateVocabulary-request-VocabularyFileUri"></a>
 The S3 location of the text file that contains the definition of the custom vocabulary\. The URI must be in the same region as the API endpoint that you are calling\. The general form is   
- ` https://s3-<aws-region>.amazonaws.com/<bucket-name>/<keyprefix>/<objectkey> `   
+ ` https://s3.<aws-region>.amazonaws.com/<bucket-name>/<keyprefix>/<objectkey> `   
 For example:  
- `https://s3-us-east-1.amazonaws.com/examplebucket/vocab.txt`   
+ `https://s3.us-east-1.amazonaws.com/examplebucket/vocab.txt`   
 For more information about S3 object names, see [Object Keys](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#object-keys) in the *Amazon S3 Developer Guide*\.  
 For more information about custom vocabularies, see [Custom Vocabularies](http://docs.aws.amazon.com/transcribe/latest/dg/how-it-works.html#how-vocabulary)\.  
 Type: String  

--- a/doc_source/API_Media.md
+++ b/doc_source/API_Media.md
@@ -6,10 +6,10 @@ Describes the input media file in a transcription request\.
 
  **MediaFileUri**   <a name="transcribe-Type-Media-MediaFileUri"></a>
 The S3 location of the input media file\. The URI must be in the same region as the API endpoint that you are calling\. The general form is:  
- ` https://s3-<aws-region>.amazonaws.com/<bucket-name>/<keyprefix>/<objectkey> `   
+ ` https://s3.<aws-region>.amazonaws.com/<bucket-name>/<keyprefix>/<objectkey> `   
 For example:  
- `https://s3-us-east-1.amazonaws.com/examplebucket/example.mp4`   
- `https://s3-us-east-1.amazonaws.com/examplebucket/mediadocs/example.mp4`   
+ `https://s3.us-east-1.amazonaws.com/examplebucket/example.mp4`   
+ `https://s3.us-east-1.amazonaws.com/examplebucket/mediadocs/example.mp4`   
 For more information about S3 object names, see [Object Keys](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#object-keys) in the *Amazon S3 Developer Guide*\.  
 Type: String  
 Length Constraints: Minimum length of 1\. Maximum length of 2000\.  

--- a/doc_source/API_UpdateVocabulary.md
+++ b/doc_source/API_UpdateVocabulary.md
@@ -33,9 +33,9 @@ Required: No
 
  ** [VocabularyFileUri](#API_UpdateVocabulary_RequestSyntax) **   <a name="transcribe-UpdateVocabulary-request-VocabularyFileUri"></a>
 The S3 location of the text file that contains the definition of the custom vocabulary\. The URI must be in the same region as the API endpoint that you are calling\. The general form is   
- ` https://s3-<aws-region>.amazonaws.com/<bucket-name>/<keyprefix>/<objectkey> `   
+ ` https://s3.<aws-region>.amazonaws.com/<bucket-name>/<keyprefix>/<objectkey> `   
 For example:  
- `https://s3-us-east-1.amazonaws.com/examplebucket/vocab.txt`   
+ `https://s3.us-east-1.amazonaws.com/examplebucket/vocab.txt`   
 For more information about S3 object names, see [Object Keys](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#object-keys) in the *Amazon S3 Developer Guide*\.  
 For more information about custom vocabularies, see [Custom Vocabularies](http://docs.aws.amazon.com/transcribe/latest/dg/how-it-works.html#how-vocabulary)\.  
 Type: String  


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
Fixed the S3 URL format to "s3.aws-region..." not "s3-aws-region...", as the former did not work  (in boto3) and the latter did.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
