### PR TITLE
Fix IAM policy quoting examples

### DIFF
--- a/doc_source/security_iam_id-based-policy-examples.md
+++ b/doc_source/security_iam_id-based-policy-examples.md
@@ -88,8 +88,8 @@ The user's IAM policy must have Amazon S3 permissions to access the S3 bucket wh
         {
             "Effect": "Allow",
             "Action": [
-                        “s3:GetObject”,
-             ],
+                "s3:GetObject"
+            ],
             "Resource": "S3 bucket location"
         }
     ]


### PR DESCRIPTION
Small formatting change. One of the example policies had "smart" quotes and a trailing comma that made it invalid JSON and formatted incorrectly by the syntax highlighter.