### PR TITLE
Fix typo in X-Amz-Credential param

### DIFF
--- a/doc_source/websocket.md
+++ b/doc_source/websocket.md
@@ -120,7 +120,7 @@ Create a string that includes information from your request in a standardized fo
 
    ```
    canonical_querystring  = "X-Amz-Algorithm=" + algorithm
-   canonical_querystring += "&X-Amz-Credentials="+ access key + "/" + credential_scope
+   canonical_querystring += "&X-Amz-Credential="+ access key + "/" + credential_scope
    canonical_querystring += "&X-Amz-Date=" + amz_date 
    canonical_querystring += "&X-Amz-Expires=300"
    canonical_querystring += "&X-Amz-Security-Token=" + token


### PR DESCRIPTION
Please considers fixing this, finding why requests are failing after copying this block of code can be quite tricky.

*Issue #, if available:* Typo in X-Amz-Credential param

*Description of changes:* Fix typo


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
